### PR TITLE
[MAN-456] The iphone-simulator nugets now have the same base name as the iOS nuget (Laerdal.Dfu.Bindings.iOS) and differ only by a certain postfix to the package version

### DIFF
--- a/Laerdal.Dfu.Bindings.iOSSimulator.Arm64/Laerdal.Dfu.Bindings.iOSSimulator.Arm64.csproj
+++ b/Laerdal.Dfu.Bindings.iOSSimulator.Arm64/Laerdal.Dfu.Bindings.iOSSimulator.Arm64.csproj
@@ -1,8 +1,27 @@
+<!-- to future maintainers   if you are asking yourself:                                                                                                                                      -->
+<!-- to future maintainers                                                                                                                                                                    -->
+<!-- to future maintainers   "can't we just use the lipo cli to combine iphonesimulator-arm64 and iphoneos-arm64 into a single native binary and generate a single nuget instead of two?"     -->
+<!-- to future maintainers                                                                                                                                                                    -->
+<!-- to future maintainers   the answer is:                                                                                                                                                   -->
+<!-- to future maintainers                                                                                                                                                                    -->
+<!-- to future maintainers   lipo does not (at the time of this writing and probably in the future) support combining two arm64 binaries into one   this is why we need to have two separate  -->
+<!-- to future maintainers   nugets with that differ only in version: the iphonesimulator nuget is marked as prelease with the 'ios-sim-arm64' prefix!  both nugets get uploaded to the       -->
+<!-- to future maintainers   nuget server                                                                                                                                                     -->
+<!-- to future maintainers                                                                                                                                                                    -->
+<!-- to future maintainers            Laerdal.Dfu.Bindings.iOS     version: 1.2.3                                                                                                             -->
+<!-- to future maintainers            Laerdal.Dfu.Bindings.iOS     version: 1.2.3-ios-sim-x64                                                                                                 -->
+<!-- to future maintainers            Laerdal.Dfu.Bindings.iOS     version: 1.2.3-ios-sim-arm64                                                                                               -->
+<!-- to future maintainers                                                                                                                                                                    -->
+
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ProjectRootPath>$(MSBuildThisFileDirectory)</ProjectRootPath>
 
-        <Laerdal_Package_Name>Laerdal.Dfu.Bindings.iOSSimulator.Arm64</Laerdal_Package_Name>
+        <Laerdal_Package_Tags>Simulators</Laerdal_Package_Tags>
+        <Laerdal_Package_Name>Laerdal.Dfu.Bindings.iOS</Laerdal_Package_Name>
+        
+        <!-- this is absolutely vital! -->
+        <Laerdal_Package_Version_Postfix>-ios-sim-arm64</Laerdal_Package_Version_Postfix>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Laerdal.Dfu.Bindings.iOSSimulator.x64/Laerdal.Dfu.Bindings.iOSSimulator.x64.csproj
+++ b/Laerdal.Dfu.Bindings.iOSSimulator.x64/Laerdal.Dfu.Bindings.iOSSimulator.x64.csproj
@@ -1,8 +1,26 @@
+<!-- to future maintainers   if you are asking yourself:                                                                                                                                      -->
+<!-- to future maintainers                                                                                                                                                                    -->
+<!-- to future maintainers   "can't we just use the lipo cli to combine iphonesimulator-x64 and iphoneos-arm64 into a single native binary and generate a single nuget instead of two?"       -->
+<!-- to future maintainers                                                                                                                                                                    -->
+<!-- to future maintainers   the answer is:                                                                                                                                                   -->
+<!-- to future maintainers                                                                                                                                                                    -->
+<!-- to future maintainers   lipo does indeed support that sort of thing   however it does NOT support the same for the new iphonesimulator-arm64 approach for M1+ apple silicon   we chose   -->
+<!-- to future maintainers   to side with the new approach used in iphonesimulator-arm64 in which we generate separate nuget packages differentiated by a phony version-postfix like so:      -->
+<!-- to future maintainers                                                                                                                                                                    -->
+<!-- to future maintainers            Laerdal.Dfu.Bindings.iOS     version: 1.2.3                                                                                                             -->
+<!-- to future maintainers            Laerdal.Dfu.Bindings.iOS     version: 1.2.3-ios-sim-x64                                                                                                 -->
+<!-- to future maintainers            Laerdal.Dfu.Bindings.iOS     version: 1.2.3-ios-sim-arm64                                                                                               -->
+<!-- to future maintainers                                                                                                                                                                    -->
+
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ProjectRootPath>$(MSBuildThisFileDirectory)</ProjectRootPath>
 
-        <Laerdal_Package_Name>Laerdal.Dfu.Bindings.iOSSimulator.x64</Laerdal_Package_Name>
+        <Laerdal_Package_Tags>Simulators</Laerdal_Package_Tags>
+        <Laerdal_Package_Name>Laerdal.Dfu.Bindings.iOS</Laerdal_Package_Name>
+
+        <!-- this is absolutely vital! -->
+        <Laerdal_Package_Version_Postfix>-ios-sim-x64</Laerdal_Package_Version_Postfix>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Laerdal.Scripts/Laerdal.Builder.targets
+++ b/Laerdal.Scripts/Laerdal.Builder.targets
@@ -175,11 +175,12 @@
         <Error Condition=" '$(Laerdal_Dependency_Tracker_Api_Key_File_Path)'             == '' " Text="'Laerdal_Dependency_Tracker_Api_Key_File_Path' has to be set. Please call this script again with the argument '/p:Laerdal_Dependency_Tracker_Api_Key_File_Path=...'"/>
         <Error Condition=" '$(Laerdal_Dependency_Tracker_Private_Signing_Key_File_Path)' == '' " Text="'Laerdal_Dependency_Tracker_Private_Signing_Key_File_Path' has to be set. Please call this script again with the argument '/p:Laerdal_Dependency_Tracker_Private_Signing_Key_File_Path=...'"/>
 
+        <!--  IOS  -->
         <PropertyGroup>
             <!-- notice that we intentionally use $(Laerdal_Version_Assembly) instead of $(Laerdal_Version_Full) -->
             <!-- because cyclonedx inherently ear-tags sboms with the former rather than the later               -->
 
-            <_Laerdal_Project_iOS_Name>$([System.IO.Path]::GetFileName('$(Laerdal_Project_iOS)').Replace('.csproj', ''))</_Laerdal_Project_iOS_Name>
+            <_Laerdal_Project_Name>$([System.IO.Path]::GetFileName('$(Laerdal_Project_iOS)').Replace('.csproj', ''))</_Laerdal_Project_Name>
 
             <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --project-version &quot;$(Laerdal_Version_Assembly)&quot;</_Laerdal_Sbom_Script_Parameters>
             <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --output-directory-path &quot;$(PackageOutputPath)&quot;</_Laerdal_Sbom_Script_Parameters>
@@ -191,7 +192,7 @@
             <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --csproj-classifier &quot;Library&quot;</_Laerdal_Sbom_Script_Parameters>
             <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --csproj-file-path &quot;$(Laerdal_Project_iOS)&quot;</_Laerdal_Sbom_Script_Parameters>
 
-            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --project-name &quot;$(_Laerdal_Project_iOS_Name)&quot;</_Laerdal_Sbom_Script_Parameters>
+            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --project-name &quot;$(_Laerdal_Project_Name)&quot;</_Laerdal_Sbom_Script_Parameters>
             <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --output-sbom-file-name &quot;sbom.laerdal.dfu.bindings.ios.xml&quot;</_Laerdal_Sbom_Script_Parameters>
 
             <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --parent-project-name &quot;[Group(Legacy)::Laerdal.Dfu.Bindings.iOS]&quot;</_Laerdal_Sbom_Script_Parameters>
@@ -202,6 +203,37 @@
         <Message Importance="High" Text="** Generating, Singing and Uploading SBOMs:"/>
 
         <Exec Command="   bash    Laerdal.GenerateSignAndUploadSbom.sh     $(_Laerdal_Sbom_Script_Parameters)  " ConsoleToMSBuild="true" WorkingDirectory="$(Laerdal_Script_FolderPath)"/>
+
+        <!--  MACCATALYST  -->
+        <PropertyGroup>
+            <!-- notice that we intentionally use $(Laerdal_Version_Assembly) instead of $(Laerdal_Version_Full) -->
+            <!-- because cyclonedx inherently ear-tags sboms with the former rather than the later               -->
+
+            <_Laerdal_Project_Name>$([System.IO.Path]::GetFileName('$(Laerdal_Project_MacCatalyst)').Replace('.csproj', ''))</_Laerdal_Project_Name>
+
+            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --project-version &quot;$(Laerdal_Version_Assembly)&quot;</_Laerdal_Sbom_Script_Parameters>
+            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --output-directory-path &quot;$(PackageOutputPath)&quot;</_Laerdal_Sbom_Script_Parameters>
+            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --sbom-signing-key-file-path &quot;$(Laerdal_Dependency_Tracker_Private_Signing_Key_File_Path)&quot;</_Laerdal_Sbom_Script_Parameters>
+
+            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --dependency-tracker-url &quot;$(Laerdal_Dependency_Tracker_Server_Url)&quot;</_Laerdal_Sbom_Script_Parameters>
+            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --dependency-tracker-api-key-file-path &quot;$(Laerdal_Dependency_Tracker_Api_Key_File_Path)&quot;</_Laerdal_Sbom_Script_Parameters>
+
+            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --csproj-classifier &quot;Library&quot;</_Laerdal_Sbom_Script_Parameters>
+            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --csproj-file-path &quot;$(Laerdal_Project_MacCatalyst)&quot;</_Laerdal_Sbom_Script_Parameters>
+
+            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --project-name &quot;$(_Laerdal_Project_Name)&quot;</_Laerdal_Sbom_Script_Parameters>
+            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --output-sbom-file-name &quot;sbom.laerdal.dfu.bindings.maccatalyst.xml&quot;</_Laerdal_Sbom_Script_Parameters>
+
+            <_Laerdal_Sbom_Script_Parameters>$(_Laerdal_Sbom_Script_Parameters)  --parent-project-name &quot;[Group(Legacy)::Laerdal.Dfu.Bindings.MacCatalyst]&quot;</_Laerdal_Sbom_Script_Parameters>
+        </PropertyGroup>
+
+        <!-- https://docs.dependencytrack.org/usage/cicd/#large-payloads   also notice that we are forced to target           -->
+        <!-- /api/api/v1/bom instead of /api/v1/bom due to an inherent misconfiguration of laerdal's dependency-track server  -->
+        <Message Importance="High" Text="** Generating, Singing and Uploading SBOMs:"/>
+
+        <Exec Command="   bash    Laerdal.GenerateSignAndUploadSbom.sh     $(_Laerdal_Sbom_Script_Parameters)  " ConsoleToMSBuild="true" WorkingDirectory="$(Laerdal_Script_FolderPath)"/>
+
+
     </Target>
 
 </Project>

--- a/Laerdal.Scripts/Laerdal.targets
+++ b/Laerdal.Scripts/Laerdal.targets
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
         <!--<Laerdal_Package_Name>Laerdal.Dfu.Bindings.iOS</Laerdal_Package_Name>-->
-        <Laerdal_Package_Tags>Ble;Tools;Xamarin;Dfu;Bluetooth;Nordic;Semiconductor</Laerdal_Package_Tags>
+        <Laerdal_Package_Tags>$(Laerdal_Package_Tags);Ble;Tools;Xamarin;Dfu;Bluetooth;Nordic;Semiconductor</Laerdal_Package_Tags>
         <Laerdal_Package_Copyright>Laerdal Medical, Francois Raminosona</Laerdal_Package_Copyright>
         <Laerdal_Package_Description>Xamarin wrapper around Nordic.Dfu for iOS.</Laerdal_Package_Description>
 
@@ -124,7 +124,7 @@
         <PackageOutputPath>$([System.IO.Path]::GetFullPath( '$(PackageOutputPath)' ))</PackageOutputPath>
         
         <!-- Extra files and properties -->
-        <PackageTags>Laerdal;Internal;$(Laerdal_Package_Tags)</PackageTags>
+        <PackageTags>$(Laerdal_Package_Tags)</PackageTags>
         <PackageIconPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), `../icon.png`))</PackageIconPath>
         <PackageLicencePath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), `../LICENSE`))</PackageLicencePath>
         <PackageReadMePath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), `../README.md`))</PackageReadMePath>
@@ -182,12 +182,15 @@
     <!-- ==================== VERSION ==================== -->
     <PropertyGroup>
         <Laerdal_Version_Full Condition="'$(Laerdal_Version_Full)' == ''">1.0.0-local.0</Laerdal_Version_Full>
+        
         <!-- Apply Version parts according to packaging standards -->
+        <Version>$(Laerdal_Version_Full)</Version>
         <AssemblyVersion>$(Laerdal_Version_Full)</AssemblyVersion>
         <AssemblyFileVersion>$(Laerdal_Version_Full)</AssemblyFileVersion>
         <AssemblyInformationalVersion>$(Laerdal_Version_Full)</AssemblyInformationalVersion>
-        <Version>$(Laerdal_Version_Full)</Version>
-        <PackageVersion>$(Laerdal_Version_Full)</PackageVersion>
+        
+        <!-- note that it is absolutely vital to append $(Laerdal_Package_Version_Postfix) because the iphone-simulator nugets need it! -->
+        <PackageVersion>$(Laerdal_Version_Full)$(Laerdal_Package_Version_Postfix)</PackageVersion>
     </PropertyGroup>
 
     <!-- considering the highly customized nature of the build system we need to ensure that parallelization is turned off otherwise we will end up with   -->


### PR DESCRIPTION
With this new scheme on each build we generate 4 nugets like so:

     Laerdal.Dfu.Bindings.iOS           version: 1.2.3
     Laerdal.Dfu.Bindings.iOS           version: 1.2.3-ios-sim-x64    (for the legacy iphonesimulator-x86_64)
     Laerdal.Dfu.Bindings.iOS           version: 1.2.3-ios-sim-arm64  (for the new iphonesimulator-arm64)
     Laerdal.Dfu.Bindings.MacCatalyst   version: 1.2.3

The point of this change is to allow the .csproj of the MAUI apps to override the iOS package with the phony iOS package of the iphone-simulators!