### PR TITLE
[MAN-456] Re-support ios-simulator side-builds

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -28,15 +28,15 @@ env:
   SCL_DEPENDENCY_TRACKER_SERVER_URL: ${{          secrets.SCL_DEPENDENCY_TRACKER_SERVER_URL          }}
   SCL_DEPENDENCY_TRACKER_SIGNING_PRIVATE_KEY: ${{ secrets.SCL_DEPENDENCY_TRACKER_SIGNING_PRIVATE_KEY }}
 
-  DOTNET_TARGET_WORKLOAD_VERSION: "8.0.402" # dont upgrade this lightheartedly   the workload snapshot implicitly defines which versions of Android/iOS/MacCatalyst SDKs are supported
+  DOTNET_TARGET_WORKLOAD_VERSION: "8.0.405" # dont upgrade this lightheartedly   the workload snapshot implicitly defines which versions of Android/iOS/MacCatalyst SDKs are supported
 
   BINDINGS_IOS___SDK_VERSION: "18.1" # for xcodebuild
   BINDINGS_IOS___XCODE_IDE_DEV_PATH: "/Applications/Xcode_16.1.app/Contents/Developer" # for xcodebuild
-  BINDINGS_IOS___DOTNET_TARGET_PLATFORM_VERSION: "17.0" # for the csproj file
+  BINDINGS_IOS___DOTNET_TARGET_PLATFORM_VERSION: "18.0" # for the csproj file
 
   BINDINGS_MACCATALYST___SDK_VERSION: "15.1" # for xcodebuild
   BINDINGS_MACCATALYST___XCODE_IDE_DEV_PATH: "/Applications/Xcode_16.1.app/Contents/Developer" # for xcodebuild
-  BINDINGS_MACCATALYST___DOTNET_TARGET_PLATFORM_VERSION: "17.0" # for the csproj file
+  BINDINGS_MACCATALYST___DOTNET_TARGET_PLATFORM_VERSION: "18.0" # for the csproj file
 
 
 on:

--- a/Laerdal.Scripts/Laerdal.targets
+++ b/Laerdal.Scripts/Laerdal.targets
@@ -57,16 +57,16 @@
 
     <!-- ==================== TARGET PLATFORM VERSION ======================= -->
     <PropertyGroup>
-        <!-- you will need to be specific when it comes to workloads ->    dotnet workload install maui -/-version 8.0.402   -->
+        <!-- you will need to be specific when it comes to workloads ->    dotnet workload install maui -/-version 8.0.405   -->
 
         <!-- #1 these properties must be kept in sync between this file and laerdal.mcumgr.bindings.[android|ios|maccatalyst].csproj   -->
         <!-- #2 even though this is library is pure csharp we still have to specify the target-plaform-version for each target because -->
         <!--    if we dont dont the build system throws a tantrum from oct 2024 onwards                                                -->
-        <TargetPlatformVersion Condition="       '$(IsNetIOS)'         == 'true' ">17.0</TargetPlatformVersion>
+        <TargetPlatformVersion Condition="       '$(IsNetIOS)'         == 'true' ">18.0</TargetPlatformVersion>
         <TargetPlatformMinVersion Condition="    '$(IsNetIOS)'         == 'true' ">14.2</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion  Condition=" '$(IsNetIOS)'         == 'true' ">14.2</SupportedOSPlatformVersion>
 
-        <TargetPlatformVersion Condition="       '$(IsNetMacCatalyst)' == 'true' ">17.0</TargetPlatformVersion>
+        <TargetPlatformVersion Condition="       '$(IsNetMacCatalyst)' == 'true' ">18.0</TargetPlatformVersion>
         <TargetPlatformMinVersion Condition="    '$(IsNetMacCatalyst)' == 'true' ">13.1</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion  Condition=" '$(IsNetMacCatalyst)' == 'true' ">13.1</SupportedOSPlatformVersion>
     </PropertyGroup>


### PR DESCRIPTION
Side-tweak: Upgrade to ios/mac-catalyst sdks version 18.0 per MAN-470