### PR TITLE
Bump wrapped Nordic iOS-DFU-Library to 4.17.0

### DIFF
--- a/Laerdal.Dfu.Bindings.MacCatalyst/StructsAndEnums.cs
+++ b/Laerdal.Dfu.Bindings.MacCatalyst/StructsAndEnums.cs
@@ -58,6 +58,7 @@ namespace Laerdal.Dfu.Bindings.iOS
 		UnsupportedResponse = 307,
 		BytesLost = 308,
 		CrcError = 309,
+		InvalidAdvertisementName = 310,
 		InvalidInternalState = 500
 	}
 
@@ -73,14 +74,21 @@ namespace Laerdal.Dfu.Bindings.iOS
 	[Native]
 	public enum DFUState : long
 	{
+		// note: Nordic's native DFUState enum has no explicit raw values - Swift auto-assigns them
+		// sequentially by declaration order. 4.17.0 inserted Connected/Disconnected mid-sequence,
+		// which renumbers every case declared after each insertion point vs. 4.16.0. These values
+		// MUST be re-verified against the actual Swift source on every future Nordic_Package_Version
+		// bump, not just copied forward - see README's "Known issues" section.
 		Connecting = 0,
-		Starting = 1,
-		EnablingDfuMode = 2,
-		Uploading = 3,
-		Validating = 4,
-		Disconnecting = 5,
-		Completed = 6,
-		Aborted = 7
+		Connected = 1,
+		Starting = 2,
+		EnablingDfuMode = 3,
+		Uploading = 4,
+		Validating = 5,
+		Disconnecting = 6,
+		Disconnected = 7,
+		Completed = 8,
+		Aborted = 9
 	}
 
 	[Native]

--- a/Laerdal.Dfu.Bindings.iOS/StructsAndEnums.cs
+++ b/Laerdal.Dfu.Bindings.iOS/StructsAndEnums.cs
@@ -58,6 +58,7 @@ namespace Laerdal.Dfu.Bindings.iOS
 		UnsupportedResponse = 307,
 		BytesLost = 308,
 		CrcError = 309,
+		InvalidAdvertisementName = 310,
 		InvalidInternalState = 500
 	}
 
@@ -73,14 +74,21 @@ namespace Laerdal.Dfu.Bindings.iOS
 	[Native]
 	public enum DFUState : long
 	{
+		// note: Nordic's native DFUState enum has no explicit raw values - Swift auto-assigns them
+		// sequentially by declaration order. 4.17.0 inserted Connected/Disconnected mid-sequence,
+		// which renumbers every case declared after each insertion point vs. 4.16.0. These values
+		// MUST be re-verified against the actual Swift source on every future Nordic_Package_Version
+		// bump, not just copied forward - see README's "Known issues" section.
 		Connecting = 0,
-		Starting = 1,
-		EnablingDfuMode = 2,
-		Uploading = 3,
-		Validating = 4,
-		Disconnecting = 5,
-		Completed = 6,
-		Aborted = 7
+		Connected = 1,
+		Starting = 2,
+		EnablingDfuMode = 3,
+		Uploading = 4,
+		Validating = 5,
+		Disconnecting = 6,
+		Disconnected = 7,
+		Completed = 8,
+		Aborted = 9
 	}
 
 	[Native]

--- a/Laerdal.Dfu.Bindings.iOSSimulator.Arm64/StructsAndEnums.cs
+++ b/Laerdal.Dfu.Bindings.iOSSimulator.Arm64/StructsAndEnums.cs
@@ -58,6 +58,7 @@ namespace Laerdal.Dfu.Bindings.iOS
 		UnsupportedResponse = 307,
 		BytesLost = 308,
 		CrcError = 309,
+		InvalidAdvertisementName = 310,
 		InvalidInternalState = 500
 	}
 
@@ -73,14 +74,21 @@ namespace Laerdal.Dfu.Bindings.iOS
 	[Native]
 	public enum DFUState : long
 	{
+		// note: Nordic's native DFUState enum has no explicit raw values - Swift auto-assigns them
+		// sequentially by declaration order. 4.17.0 inserted Connected/Disconnected mid-sequence,
+		// which renumbers every case declared after each insertion point vs. 4.16.0. These values
+		// MUST be re-verified against the actual Swift source on every future Nordic_Package_Version
+		// bump, not just copied forward - see README's "Known issues" section.
 		Connecting = 0,
-		Starting = 1,
-		EnablingDfuMode = 2,
-		Uploading = 3,
-		Validating = 4,
-		Disconnecting = 5,
-		Completed = 6,
-		Aborted = 7
+		Connected = 1,
+		Starting = 2,
+		EnablingDfuMode = 3,
+		Uploading = 4,
+		Validating = 5,
+		Disconnecting = 6,
+		Disconnected = 7,
+		Completed = 8,
+		Aborted = 9
 	}
 
 	[Native]

--- a/Laerdal.Dfu.Bindings.iOSSimulator.x64/StructsAndEnums.cs
+++ b/Laerdal.Dfu.Bindings.iOSSimulator.x64/StructsAndEnums.cs
@@ -58,6 +58,7 @@ namespace Laerdal.Dfu.Bindings.iOS
 		UnsupportedResponse = 307,
 		BytesLost = 308,
 		CrcError = 309,
+		InvalidAdvertisementName = 310,
 		InvalidInternalState = 500
 	}
 
@@ -73,14 +74,21 @@ namespace Laerdal.Dfu.Bindings.iOS
 	[Native]
 	public enum DFUState : long
 	{
+		// note: Nordic's native DFUState enum has no explicit raw values - Swift auto-assigns them
+		// sequentially by declaration order. 4.17.0 inserted Connected/Disconnected mid-sequence,
+		// which renumbers every case declared after each insertion point vs. 4.16.0. These values
+		// MUST be re-verified against the actual Swift source on every future Nordic_Package_Version
+		// bump, not just copied forward - see README's "Known issues" section.
 		Connecting = 0,
-		Starting = 1,
-		EnablingDfuMode = 2,
-		Uploading = 3,
-		Validating = 4,
-		Disconnecting = 5,
-		Completed = 6,
-		Aborted = 7
+		Connected = 1,
+		Starting = 2,
+		EnablingDfuMode = 3,
+		Uploading = 4,
+		Validating = 5,
+		Disconnecting = 6,
+		Disconnected = 7,
+		Completed = 8,
+		Aborted = 9
 	}
 
 	[Native]

--- a/Laerdal.Scripts/Laerdal.Builder.targets
+++ b/Laerdal.Scripts/Laerdal.Builder.targets
@@ -32,7 +32,7 @@
         <Laerdal_Script_FolderPath>$(MSBuildThisFileDirectory)</Laerdal_Script_FolderPath>
 
         <!-- version: {Nordic_Package_Version}.{build_number}   override with /p:Laerdal_Version_Full=... -->
-        <Nordic_Package_Version Condition=" '$(Nordic_Package_Version)' == '' ">4.16.0</Nordic_Package_Version>
+        <Nordic_Package_Version Condition=" '$(Nordic_Package_Version)' == '' ">4.17.0</Nordic_Package_Version>
         <Laerdal_Revision Condition=" '$(Laerdal_Revision)' == '' and '$(GITHUB_RUN_NUMBER)' != '' ">$([MSBuild]::Add(43857, $(GITHUB_RUN_NUMBER)))</Laerdal_Revision>
         <Laerdal_Revision Condition=" '$(Laerdal_Revision)' == '' ">0</Laerdal_Revision>
         <Laerdal_Version_Full     Condition=" '$(Laerdal_Version_Full)'     == '' ">$(Nordic_Package_Version).$(Laerdal_Revision)</Laerdal_Version_Full>

--- a/Laerdal.Scripts/Laerdal.targets
+++ b/Laerdal.Scripts/Laerdal.targets
@@ -49,7 +49,7 @@
     <PropertyGroup>
         <!-- when updating this version it is imperative to also update it manually inside laerdal.builder.targets too -->
         <!-- failing to do so will cause the release mechanism to fail in terms of creating a new release on github    -->
-        <Nordic_Package_Version Condition=" '$(Nordic_Package_Version)' == '' ">4.16.0</Nordic_Package_Version>
+        <Nordic_Package_Version Condition=" '$(Nordic_Package_Version)' == '' ">4.17.0</Nordic_Package_Version>
         <Laerdal_Revision Condition="       '$(Laerdal_Revision)'       == '' ">0</Laerdal_Revision>
 
         <Laerdal_Version_Full Condition=" '$(Laerdal_Version_Full)' == '' ">$(Nordic_Package_Version).$(Laerdal_Revision)</Laerdal_Version_Full>

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ when unset, and `xcodebuild` will fail outright if that exact SDK isn't present.
 `Artifacts/`. To pin an explicit version:
 
 ```bash
-dotnet msbuild Laerdal.Scripts/Laerdal.Builder.targets /m:1 /p:Laerdal_Version_Full=4.16.0.123
+dotnet msbuild Laerdal.Scripts/Laerdal.Builder.targets /m:1 /p:Laerdal_Version_Full=4.17.0.123
 ```
 
 If Carthage fails outright, clear its cache and retry:
@@ -130,17 +130,30 @@ silently reintroduced.
   simulator-specific prerelease package for your architecture:
 
   ```xml
-  <PackageReference Include="Laerdal.Dfu.Bindings.iOS" Version="4.16.0.123-ios-sim-arm64">
+  <PackageReference Include="Laerdal.Dfu.Bindings.iOS" Version="4.17.0.123-ios-sim-arm64">
       <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PackageReference>
   ```
 
 - **Manual version-sync footgun.**
-  `Nordic_Package_Version` (currently `4.16.0`) is defined in both `Laerdal.Builder.targets` and
+  `Nordic_Package_Version` (currently `4.17.0`) is defined in both `Laerdal.Builder.targets` and
   `Laerdal.targets`, and letting the two drift apart breaks the GitHub release step silently. CI
   (`ci.yml`) reads this value directly out of `Laerdal.targets` rather than keeping its own copy,
   so there are only 2 places left to keep in sync, not 3 — but they're still manual. Bump the
   Nordic version in both `.targets` files together.
+
+- **Bumping `Nordic_Package_Version` can silently corrupt `DFUState` without any build error.**
+  Nordic's native `DFUState` Swift enum has no explicit raw values — Swift assigns them
+  sequentially by declaration order — and this repo's `[Native] enum : long` binding
+  (`StructsAndEnums.cs`, duplicated per-project) hardcodes those numbers. `4.16.0 → 4.17.0`
+  inserted `connected`/`disconnected` mid-sequence, which renumbered every case declared after
+  each insertion point (`Completed`/`Aborted` shifted from `6`/`7` to `8`/`9`). Copying the old
+  numbers forward would have consumers silently misreport DFU states — e.g. an actual
+  `Disconnecting` event read back as `Completed` — with no compile-time signal at all.
+  **Before ever bumping this version, diff the actual Swift source for `DFUState` (and any other
+  `[Native] enum`-bound type) against the previous tag — never assume "additive-sounding"
+  changelog entries are safe.** `DFUError` is safe from this specific trap since every one of its
+  cases has an explicit raw value in Nordic's source.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Bumps `Nordic_Package_Version` 4.16.0 → 4.17.0 in both `.targets` files.
- **Not just a version bump**: Nordic's `DFUState` Swift enum has no explicit raw values, and 4.17.0 inserts `connected`/`disconnected` mid-sequence, which renumbers every case declared after each insertion point vs. 4.16.0 (`Completed`/`Aborted` shift from `6`/`7` to `8`/`9`). Verified directly against the Swift source (not just the changelog, which describes this as a harmless additive change) - copying the old raw values forward would have silently misreported DFU states at runtime with zero build-time signal. Updated the `[Native] enum` binding in all 4 project copies of `StructsAndEnums.cs` to match.
- Also adds `DFUError.InvalidAdvertisementName = 310` (safe/additive - `DFUError` uses explicit raw values throughout, unlike `DFUState`).
- Documents the raw-value-shift risk in the README's Known Issues so a future Nordic bump doesn't reintroduce this class of bug.

## Test plan
- [x] Full local build against the real 4.17.0 native library - all 4 packages produced, no new warnings/errors beyond pre-existing ones.
- [ ] CI green on this PR